### PR TITLE
Handle http(s) request errors

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -124,6 +124,13 @@ RobotsParser.prototype.read = function(after_parse) {
 
 
   });
+
+  request.on('error', function(error) {
+    ut.d('RobotsParser.read: request error: ' + error)
+    self.error = error;
+    after_parse(self, false);
+  });
+
   request.end();
 };
 


### PR DESCRIPTION
Add a handler for the 'error' event on the request object.
It sets a `error` field on the parser object and calls `after_parse`
with `success = false`
