### PR TITLE
Fix Rule.appliesTo to return true when the rule has end_char ($) but no wildcard (*), and path === url + end_char.

### DIFF
--- a/lib/rule.js
+++ b/lib/rule.js
@@ -43,13 +43,13 @@ Rule.prototype.appliesTo = function(url) {
   var url = ut.quote(ut.unquote(url));
   ut.d(' * Rule.appliesTo, url: '+url+', path: '+this.path);
 
-  if (this.path === '*' || url.indexOf(this.path) === 0)
+  var have_strict_end = this.path.indexOf(end_char) + end_char.length === this.path.length;
+  if (this.path === '*' || url.indexOf(this.path) === 0 || (have_strict_end && this.path === url + end_char))
     return true;
   else if (this.path.indexOf('*') === -1)
     return false;
   else {
     // we have globed match
-    var have_strict_end = this.path.indexOf(end_char) + end_char.length === this.path.length;
     var parts_to_match = this.path.split('*');
     url = url + end_char;
 


### PR DESCRIPTION
The strict end pattern was only matched when the text had a wildcard. This pull requests adds the case where we have strict end but no wildcard.