### PR TITLE
Fix redirection when there is no location header.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -160,7 +160,7 @@ RobotsParser.prototype.read = function(after_parse) {
       resp.resume();
       after_parse(self, false);
     }
-    else if ([301, 302].indexOf(resp.statusCode) > -1) {
+    else if ([301, 302].indexOf(resp.statusCode) > -1 && 'location' in resp.headers) {
       // redirect
       var redirect_url = urlparser.resolve(
           self.url,


### PR DESCRIPTION
If the connection receives a redirection status code, but there is no location header, ignore the redirection and read the data.