### PR TITLE
Guard against infinite redirect loop

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -29,6 +29,7 @@ function RobotsParser (url, options, after_parse) {
   this.defaultEntry = '';
   this.disallowAll = false;
   this.statusCode = -1;
+  this.redirectLimit = 5;
   this.allowAll = false;
   if (null === options){
     this.options = {};
@@ -161,13 +162,20 @@ RobotsParser.prototype.read = function(after_parse) {
       after_parse(self, false);
     }
     else if ([301, 302].indexOf(resp.statusCode) > -1 && 'location' in resp.headers) {
-      // redirect
-      var redirect_url = urlparser.resolve(
+      resp.resume();
+      if (self.redirectLimit <= 0) {
+        ut.d('RobotsParser.read: Redirect limit encountered');
+        self.allowAll = true;
+        after_parse(self, false);
+      } else {
+        self.redirectLimit--;
+        // redirect
+        var redirect_url = urlparser.resolve(
           self.url,
           resp.headers.location
-      )
-      resp.resume();
-      self.setUrl(redirect_url, after_parse);
+        );
+        self.setUrl(redirect_url, after_parse);
+      }
     }
     else {
       resp.setEncoding('utf8');

--- a/tests/parser.read.test.js
+++ b/tests/parser.read.test.js
@@ -274,5 +274,49 @@ module.exports = {
         }
     );
   },
+  '10. Test compound redirect': function() {
+    testRead(
+        'http://testsite10.com/robots.txt',
+        {
+            'http://testsite10.com/robots.txt': {
+                'statusCode': 301,
+                'headers': { 'location': 'http://testsite10.com/redirect1.txt' }
+            },
+            'http://testsite10.com/redirect1.txt': {
+                'statusCode': 302,
+                'headers': { 'location': 'http://testsite10.com/redirect2.txt' }
+            },
+            'http://testsite10.com/redirect2.txt': {
+                'statusCode': 200,
+                'chunks': default_chunks
+            }
+        },
+        {
+            'success': true,
+            'disallowed': false,
+            'allowed': true,
+        }
+    );
+  },
+  '11. Test infinite redirect (treat as 404)': function() {
+    testRead(
+        'http://testsite11.com/robots.txt',
+        {
+            'http://testsite11.com/robots.txt': {
+                'statusCode': 301,
+                'headers': { 'location': 'https://testsite11.com/robots.txt' }
+            },
+            'https://testsite11.com/robots.txt': {
+                'statusCode': 301,
+                'headers': { 'location': 'http://testsite11.com/robots.txt' }
+            }
+        },
+        {
+            'success': false,
+            'disallowed': true,
+            'allowed': true,
+        }
+    );
+  },
 }
 


### PR DESCRIPTION
Recently we encountered a situation where, due to a misconfigured server, a request to a robots.txt file resulted in an infinite redirect loop between the `http` and `https` protocols. This PR adds a guard for these kinds of situations. I followed [Google's specification](https://developers.google.com/webmasters/control-crawl-index/docs/robots_txt#handling-http-result-codes) in deciding how to deal with this:

> Redirects will generally be followed until a valid result can be found (or a loop is recognized). We will follow a limited number of redirect hops (RFC 1945 for HTTP/1.0 allows up to 5 hops) and then stop and treat it as a 404.