### PR TITLE
Do not leak 'clone' as a global variable

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -52,7 +52,7 @@ function RobotsParser (url, options, after_parse) {
  * @param {Object} parserToClone JSON representation
  * @returns {RobotsParser}
  */
-exports.clone = clone = function(parserToClone) {
+exports.clone = function(parserToClone) {
   var parser = new RobotsParser ();
   var parseEntry = function(value){
     var defaultEntry = new Entry();


### PR DESCRIPTION
Hello,

The clone method was leaked as a global variable, I didn't find any reason about that so I suggest to remove it.

Thanks for your work!