### PR TITLE
Add getDisallowedPaths method

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ parse and answer questions about a single robots.txt file.
     userAgent can fetch url. Return true/false.
   * **getCrawlDelay(userAgent)** — returns Crawl-delay for the certain userAgent
   * **getSitemaps(sitemaps)** — gets Sitemaps from parsed robots.txt
+  * **getDisallowedPaths(userAgent)** — gets paths explictly disallowed for the user agent specified AND *
 
 License
 -------

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -38,7 +38,7 @@ function RobotsParser (url, options, after_parse) {
   } else if (typeof options === 'object'){
     this.options = options;
   }
-  this.options = this.options || {}; 
+  this.options = this.options || {};
   this.options.headers = this.options.headers || {};
   this.options.headers.userAgent = this.options.headers.userAgent || 'Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/20100101 Firefox/5.0';;
 
@@ -450,6 +450,37 @@ RobotsParser.prototype.toString = function() {
     };
     res.push(">");
     return res.join('\n');
+};
+
+/**
+ * Returns an array of pages explicitly disallowed in the site's robots.txt file
+ *
+ */
+RobotsParser.prototype.getDisallowedPaths = function(userAgent) {
+    var entry;
+    var rule;
+    var result = [];
+    // find entries matching this user agent
+    for (var i = 0; i < this.entries.length; i++) {
+      entry = this.entries[i];
+      if (entry.appliesTo(userAgent)) {
+        for (var j = 0; j < entry.rules.length; j++) {
+          rule = entry.rules[j];
+          if (!rule.allowance) {
+            result.push(decodeURIComponent(rule.path));
+          }
+        }
+      }
+    }
+    // add the default rules
+    for (var j = 0; j < this.defaultEntry.rules.length; j++) {
+      rule = this.defaultEntry.rules[j];
+      if (!rule.allowance) {
+        result.push(decodeURIComponent(rule.path));
+      }
+    }
+
+    return result;
 };
 
 /**

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -49,11 +49,11 @@ function testFetch (parser, url, isGood, agent) {
     }
 
     // Sync Test
-    assert.eql( parser.canFetchSync(agent, url), isGood,
+    assert.strictEqual( parser.canFetchSync(agent, url), isGood,
         'URL must be '+debug_str+': '+url+', User-Agent: '+agent+', [sync]');
     // Async Test
     parser.canFetch(agent, url, function (access, url, reason) {
-      assert.eql(access, isGood, 'URL must be '+debug_str+': '+url+
+      assert.strictEqual(access, isGood, 'URL must be '+debug_str+': '+url+
                                               ', User-Agent: '+agent+', [async]');
     });
 }
@@ -303,9 +303,54 @@ module.exports = {
         'Sitemap: '+test_sitemap[1]
       ];
     parser.parse(test_robots_txt).getSitemaps(function(get_sitemaps){
-      assert.eql(get_sitemaps, test_sitemap, 'Incorrect sitemaps: '+
+      assert.deepEqual(get_sitemaps, test_sitemap, 'Incorrect sitemaps: '+
                                               test_sitemap+', got: '+
                                               get_sitemaps);
     });
+  },
+  '19. get disallowed paths (user agent match)': function() {
+    var parser = new robots.RobotsParser()
+      , test_paths = [
+          '/c/',
+          '/a/*.json',
+          '/b/'
+        ]
+      , test_robots_txt = [
+        'User-Agent: *',
+        'Disallow: /a/*.json',
+        'Allow: /a/',
+        'Allow: /b/*.html',
+        'Disallow: /b/',
+        'User-Agent: test',
+        'Disallow: /c/',
+      ];
+
+    var disallowedPaths = parser.parse(test_robots_txt).getDisallowedPaths('test');
+
+    assert.deepEqual(disallowedPaths, test_paths, 'Incorrect paths: '+
+                                            test_paths+', got: '+
+                                            disallowedPaths);
+  },
+  '20. get disallowed paths (defaults only)': function() {
+    var parser = new robots.RobotsParser()
+      , test_paths = [
+          '/a/*.json',
+          '/b/'
+        ]
+      , test_robots_txt = [
+        'User-Agent: *',
+        'Disallow: /a/*.json',
+        'Allow: /a/',
+        'Allow: /b/*.html',
+        'Disallow: /b/',
+        'User-Agent: test',
+        'Disallow: /c/',
+      ];
+
+    var disallowedPaths = parser.parse(test_robots_txt).getDisallowedPaths('example');
+
+    assert.deepEqual(disallowedPaths, test_paths, 'Incorrect paths: '+
+                                            test_paths+', got: '+
+                                            disallowedPaths);
   },
 };


### PR DESCRIPTION
Add a `getDisallowedPaths` method to return an array of all the paths explicitly blocked for the specified user agent AND the *  "UA".

Note: I couldn't work out how the tests executed so I wrote a quick test runner 

```javascript
const tests = require('./tests/parser.test');

Object.keys(tests).forEach((testName) => {
  console.log(testName);
  tests[testName]();
});
```

but that flagged up that that the `assert.eql` method doesn't exist in node 8, so I had to change the tests that relied on it to `strictEqual` or `deepEqual`.

Any issues please let me know 🙂 