### PR TITLE
Fix incorrect JSDoc comments + add linting of them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swp
 env/
 node_modules/
+yarn.lock
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@
  * MIT Licensed
  */
 
+ // @ts-check
+/// <reference types="node" />
+
 module.exports = require('./lib/parser');
 
 /**
@@ -14,6 +17,7 @@ var fs = require('fs')
   , pack_file = path.join(__dirname, 'package.json');
 
 if ( !module.exports.version ) {
+  /** @type {String} */
   module.exports.version = JSON.parse(
     fs.readFileSync(pack_file, 'utf8')).version;
 }

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -3,6 +3,9 @@
  * Copyright(c) 2011 Eugene Kalinin
  * MIT Licensed
  */
+
+/// <reference types="node" />
+
 var ut = require('./utils');
 
 exports.Entry = Entry;
@@ -21,7 +24,7 @@ function Entry () {
 /**
  * Check if this entry applies to the specified agent
  *
- * @param {String} useragent User-Agent string
+ * @param {String} userAgent User-Agent string
  * @return {Boolean}
  */
 Entry.prototype.appliesTo = function(userAgent) {
@@ -64,6 +67,16 @@ Entry.prototype.allowance = function(url) {
   return true;
 };
 
+/**
+ * @param {String} crawl_delay 
+ */
+Entry.prototype.setCrawlDelay = function (crawl_delay) {
+  this.crawl_delay = crawl_delay;
+};
+
+/**
+ * @returns {String}
+ */
 Entry.prototype.toString = function() {
   var res = [];
   for (var i = this.userAgents.length - 1; i >= 0; i--) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -4,6 +4,8 @@
  * MIT Licensed
  */
 
+/// <reference types="node" />
+
 var Rule = require('./rule').Rule
   , Entry = require('./entry').Entry
   , urlparser = require('url')
@@ -16,17 +18,22 @@ exports.https = require('https');
 exports.RobotsParser = RobotsParser;
 
 /**
+ * @typedef {function(RobotsParser, boolean): void} after_parse_callback
+ */
+
+/**
  * Provides a set of methods to read, parse and answer
  * questions about a single robots.txt file.
  *
  * @constructor
- * @param {String} url
- * @param {String} userAgent User-Agent for fetching robots.txt
+ * @param {String} [url]
+ * @param {String|Object<String,any>} [options] Either a User-Agent string for fetching robots.txt or an options object with request arguments
+ * @param {after_parse_callback} [after_parse]
  */
 function RobotsParser (url, options, after_parse) {
   this.entries = [];
   this.sitemaps = [];
-  this.defaultEntry = '';
+  this.defaultEntry;
   this.disallowAll = false;
   this.statusCode = -1;
   this.redirectLimit = 5;
@@ -95,7 +102,7 @@ exports.clone = function(parserToClone) {
  * Sets the URL referring to a robots.txt file
  *
  * @param {String} url
- * @param {String} read   Optional, default=true. Immediate read robots.txt
+ * @param {Boolean|after_parse_callback} [read] Optional, default=true. Immediate read robots.txt
  *                        if read is a callback function, pass it through to this.read
  */
 RobotsParser.prototype.setUrl = function(url, read) {
@@ -113,19 +120,22 @@ RobotsParser.prototype.setUrl = function(url, read) {
 /**
  * Reads the robots.txt URL and feeds it to the parser
  *
- * @param {Function} callback called after remote robots.txt is downloaded and parsed
+ * @param {after_parse_callback} [after_parse] called after remote robots.txt is downloaded and parsed
  */
 RobotsParser.prototype.read = function(after_parse) {
   var self = this;
   var url = urlparser.parse(this.url);
   var port;
+  /** @type {typeof import("https")} */
   var protocol;
   if (url.protocol == 'https:') {
     protocol = exports.https;
   } else {
+    // @ts-ignore
     protocol = exports.http;
   }
 
+  /** @type {import("https").RequestOptions|import("http").RequestOptions} */
   var request_args = {
       'hostname': url.hostname,
       'port': url.port || port,
@@ -143,7 +153,7 @@ RobotsParser.prototype.read = function(after_parse) {
   if(typeof(after_parse) !== "function") {
     after_parse = function(obj, success) { };
   }
-  self.chunks = [];
+  this.chunks = [];
   request.on('response', function(resp) {
     ut.d('RobotsParser.read: get response, code: '+resp.statusCode);
 
@@ -197,6 +207,7 @@ RobotsParser.prototype.read = function(after_parse) {
 
   request.on('error', function(error) {
     ut.d('RobotsParser.read: request error: ' + error)
+    // @ts-ignore
     self.error = error;
     after_parse(self, false);
   });
@@ -310,7 +321,7 @@ RobotsParser.prototype.parse = function(lines) {
 
       case 'crawl-delay':
         if (state !== STATE_START) {
-          entry.crawl_delay = value;
+          entry.setCrawlDelay(value);
           state = STATE_SAW_ALLOW_OR_DISALLOW;
         }
     }
@@ -421,10 +432,7 @@ RobotsParser.prototype.canFetch = function(userAgent, url, callback) {
  * Crawl-delay.
  *
  * @param {String}    userAgent
- * @param {String}    url
- * @param {Function}  callback    function (access, url, rule) { ... }
- * @return {Number} or undefined
- *
+ * @return {String|void}
  */
 RobotsParser.prototype.getCrawlDelay = function (userAgent) {
   var entry;
@@ -443,7 +451,7 @@ RobotsParser.prototype.getCrawlDelay = function (userAgent) {
  */
 RobotsParser.prototype.toString = function() {
     var res = [];
-    res.push("<Parser: Crawler User Agent: " + this.userAgent);
+    res.push("<Parser: Crawler User Agent: " + this.options.headers.userAgent);
     res.push(this.defaultEntry.toString());
     for (var i in this.entries) {
         res.push(this.entries[i].toString());
@@ -490,7 +498,6 @@ RobotsParser.prototype.getDisallowedPaths = function(userAgent) {
  *
  */
 RobotsParser.prototype.toStringLite = function() {
-  var res = [];
   var agent_names = [];
   function list_agent_names(entry) {
     var names = [];
@@ -504,7 +511,7 @@ RobotsParser.prototype.toStringLite = function() {
     agent_names = agent_names.concat(list_agent_names(this.entries[i]));
   };
   var output = "<Parser: ";
-  output += "Crawler User Agent is `" + this.userAgent + "`, ";
+  output += "Crawler User Agent is `" + this.options.headers.userAgent + "`, ";
   output += "Listed Robot Agents: `" + agent_names.join('`, `');
   output += "`>";
   return output;

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -4,6 +4,8 @@
  * MIT Licensed
  */
 
+/// <reference types="node" />
+
 var ut = require('./utils');
 
 exports.Rule = Rule;
@@ -69,6 +71,9 @@ Rule.prototype.appliesTo = function(url) {
   }
 };
 
+/**
+ * @returns {String}
+ */
 Rule.prototype.toString = function() {
   return (this.allowance ? 'Allow' : 'Disallow') + ": " + this.path
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,8 @@
  * MIT Licensed
  */
 
+/// <reference types="node" />
+
 var debug = false;
 
 exports.d = function (str) {
@@ -44,7 +46,7 @@ exports.is_path_safe = function(str) {
  * @param {Object} extend_with
  */
 exports.extend = function(obj, extend_with) {
-    for(key in extend_with) {
+    for(var key in extend_with) {
         obj[key] = extend_with[key];
     }
 };

--- a/package.json
+++ b/package.json
@@ -2,21 +2,32 @@
   "name": "robots",
   "version": "0.10.1",
   "description": "Parser for robots.txt",
-  "keywords": ["robots.txt", "robotstxt", "parser"],
+  "keywords": [
+    "robots.txt",
+    "robotstxt",
+    "parser"
+  ],
   "homepage": "https://github.com/ekalinin/robots.js",
   "repository": "git://github.com/ekalinin/robots.js.git",
   "author": "Eugene Kalinin <e.v.kalinin@gmail.com>",
   "engines": {
     "node": ">= 0.6.0"
   },
+  "scripts": {
+    "test": "tsc"
+  },
   "devDependencies": {
-    "expresso": "0.8.1"
+    "@types/node": "^10.5.4",
+    "expresso": "0.8.1",
+    "typescript": "^2.9.2"
   },
   "main": "index",
   "bugs": {
-      "url": "https://github.com/ekalinin/robots.js/issues"
+    "url": "https://github.com/ekalinin/robots.js/issues"
   },
-  "licenses": [{
+  "licenses": [
+    {
       "type": "MIT"
-  }]
+    }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "files": [
+    "index.js"
+  ],
+  "include": [
+    "lib/**/*"
+  ],
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "ES2016",
+    "module": "commonjs",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "maxNodeModuleJsDepth": 2,
+
+    /* Strict Type-Checking Options */
+    "strict": true,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "strictNullChecks": false,
+
+    /* Additional Checks */
+    "noUnusedLocals": true
+  }
+}


### PR DESCRIPTION
When I started using Typescript to lint the types in my javascript files, through their JSDoc comments, I ran across an issue where it, when it found the JSDoc comments of this project, complained that I used this module wrongly.

I decided to go ahead and validate all of the JSDoc comments of this project + create a Typescript setup that can be used to continue to validate the JSDoc comments against the code

I hope this PR is not too big, I can try to break it down if you want me to.