### PR TITLE
Use require to get package version number

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,7 @@ module.exports = require('./lib/parser');
 /**
  * Framework version.
  */
-var fs = require('fs')
-  , path = require('path')
-  , pack_file = path.join(__dirname, 'package.json');
-
 if ( !module.exports.version ) {
   /** @type {String} */
-  module.exports.version = JSON.parse(
-    fs.readFileSync(pack_file, 'utf8')).version;
+  module.exports.version = require('./package.json').version;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,8 @@
     "strictNullChecks": false,
 
     /* Additional Checks */
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
Remove use of `file.readFileSync` to get the version information from `package.json`.

This resolves an issue where `package.json` may not be bundled correctly by webpack.