### PR TITLE
Fix user agent header not actually being sent

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -38,16 +38,31 @@ function RobotsParser (url, options, after_parse) {
   this.statusCode = -1;
   this.redirectLimit = 5;
   this.allowAll = false;
-  if (null === options){
+/*   if (null === options){
     this.options = {};
   } else if (typeof options === 'string'){
     this.options = { headers: {userAgent:options}};
   } else if (typeof options === 'object'){
     this.options = options;
+  } */
+  
+  if (options === null) {
+	  this.options = {};
+  } else if (typeof options === 'string') {
+	  this.options = { headers: {'User-Agent':options}};
+  } else if (typeof options === 'object') {
+	  if (options.userAgent) {
+		  this.options = {
+			  headers : {
+				  'User-Agent': options.userAgent
+			  }
+		  };
+	  }
   }
+ 
   this.options = this.options || {};
   this.options.headers = this.options.headers || {};
-  this.options.headers.userAgent = this.options.headers.userAgent || 'Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/20100101 Firefox/5.0';;
+  this.options.headers['User-Agent'] = this.options.headers['User-Agent'] || 'Mozilla/5.0 (X11; Linux i686; rv:5.0) Gecko/20100101 Firefox/5.0';
 
   this.setUrl(url, after_parse);
 }


### PR DESCRIPTION
The way user agent string is added to header requests in nodejs http module has changed. This change reflects that.